### PR TITLE
Add Powershell version

### DIFF
--- a/AcpiKey.ps1
+++ b/AcpiKey.ps1
@@ -1,0 +1,60 @@
+# based on https://gist.github.com/lwalthert/fe52f7fa98b4ea491345a0518750baa9
+# and https://github.com/NiKiZe/ACPIProductKey/blob/master/ACPIProductKeyMain.cpp
+
+$id = get-random
+$CSCode = @"
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class MsdmHelper$id {
+
+[DllImport("kernel32")]
+private static extern uint EnumSystemFirmwareTables (uint FirmwareTableProviderSignature, IntPtr pFirmwareTableBuffer, uint BufferSize);
+[DllImport("kernel32")]
+private static extern uint GetSystemFirmwareTable   (uint FirmwareTableProviderSignature, uint FirmwareTableID, IntPtr pFirmwareTableBuffer, uint BufferSize);
+
+private delegate uint GetterDlg(IntPtr pFirmwareTableBuffer, uint BufferSize);
+private static byte[] GetDataHelper(GetterDlg getter) {
+    uint bSize = getter(IntPtr.Zero, 0);
+    IntPtr FirmwareTableBuffer = Marshal.AllocHGlobal((int)bSize);
+    var buffer = new byte[bSize];
+    getter(FirmwareTableBuffer, bSize);
+    Marshal.Copy(FirmwareTableBuffer, buffer, 0, buffer.Length);
+    Marshal.FreeHGlobal(FirmwareTableBuffer);
+    return buffer;
+}
+
+public static string GetMSDM()
+{
+    const uint firmwareTableProvider = 'A' << 24 | 'C' << 16 | 'P' << 8 | 'I';
+    var buffer = GetDataHelper((p, s) => EnumSystemFirmwareTables(firmwareTableProvider, p, s));
+    string str = Encoding.ASCII.GetString(buffer);
+
+    for (int i = 0; i <= str.Length - 1; i += 4)
+    {
+        if (str.Substring(i, 4) != "MSDM")
+            continue;
+
+        const uint firmwareTableMsdm = 'M' << 24 | 'D' << 16 | 'S' << 8 | 'M'; // 0x4d44534d; // 
+        buffer = GetDataHelper((p, s) => GetSystemFirmwareTable(firmwareTableProvider, firmwareTableMsdm, p, s));
+        return Encoding.ASCII.GetString(buffer, 56, 29);
+    }
+    return null;
+}
+}
+"@
+
+# the delegate injects so we get a list, and not just one item https://stackoverflow.com/questions/65021670
+$MSDMHelper = (Add-Type -TypeDefinition $CSCode -Language CSharp -PassThru)[0]
+$key = $MSDMHelper::GetMSDM()
+
+if ($key -notLike $null) {
+  Write-Host "Trying to install found MSDM key $key"
+  cscript //Nologo c:\Windows\System32\slmgr.vbs /ipk $key | Add-content $Logfile
+  if ($?)
+  {
+    cscript //Nologo c:\Windows\System32\slmgr.vbs /ato | Add-content $Logfile
+  }
+}

--- a/slui3.ahk
+++ b/slui3.ahk
@@ -1,0 +1,62 @@
+; AutoHotKey script slui3.ahk To install product keys where it fails with: cscript //Nologo c:\Windows\System32\slmgr.vbs -ipk $key
+; Can for example be used to switch from Enterprise to Pro version
+; Tip use Chocolatey to install portable: choco install -y autohotkey.portable
+; Then run with & "C:\ProgramData\chocolatey\lib\autohotkey.portable\tools\AutoHotkey.exe" slui3.ahk $key
+; Enter a product key
+; ahk_class Shell_Dialog
+; ahk_exe SystemSettingsAdminFlows.exe
+
+; default environment
+DetectHiddenWindows, off
+SetControlDelay, 20
+
+; modified environment
+#NoEnv
+#NoTrayIcon
+DetectHiddenText, off
+SetTitleMatchMode, 2  ;contains
+
+; Run slui 3 or slui 0x03 to open the activation dialog
+Run slui.exe, , 3
+
+; define all Window title names
+GroupAdd, GrpProdKeyWin, Enter a product key ahk_class Shell_Dialog
+GroupAdd, GrpProdKeyWin, Ange en produktnyckel ahk_class Shell_Dialog
+
+GroupAdd, GrpActivateWin, Activate Windows
+GroupAdd, GrpActivateWin, Aktivera Windows
+
+GroupAdd, GrpIsActivatedWin, Windows is activated
+GroupAdd, GrpIsActivatedWin, Windows har aktiverats
+
+; Wait for main window
+WinWait, ahk_group GrpProdKeyWin, , 20
+if ErrorLevel {  ; i.e. it's not blank or zero.
+	ExitApp
+	return
+}
+WinActivate ; Make sure the found window is active
+SendInput %1% ; Send script argument as key
+Send {Enter} ; Press enter to emulate Next
+; Todo detect and valdate Next button
+;ControlClick, Button1 ; Next
+
+; Do you want to activate window, default yes
+WinWait, ahk_group GrpActivateWin, , 20
+if ErrorLevel {  ; i.e. it's not blank or zero.
+	ExitApp
+	return
+}
+WinActivate ; Use the window found by WinWait.
+Send {Enter}
+
+; You have now activated window, close
+WinWait, ahk_group GrpIsActivatedWin, , 20
+if ErrorLevel {  ; i.e. it's not blank or zero.
+	ExitApp
+	return
+}
+WinActivate ; Use the window found by WinWait.
+Send {Enter}
+
+ExitApp


### PR DESCRIPTION
Use C# and dll imports which is compiled into powershell and called to get the key

Sometimes it is not possible to install the key with `cscript //Nologo c:\Windows\System32\slmgr.vbs -ipk $key`
For example it results in "Error: 0xC004E016 Run slui.exe 0x2a 0xC004E016 ..." When key is for Win Pro, but installed version is Enterprise
This includes a AutoHotKey script that runs "slui.exe 0x03" to automate this process as well.

Include the below powershell in the grabber script as a path when `-ipk` fails, it also runs even if the script is run non interactive by executing it thru a scheduled task

```powershell
} else {
    $ahkPath="C:\ProgramData\chocolatey\lib\autohotkey.portable\tools\AutoHotkey.exe"
    if (-not ([System.IO.File]::Exists($ahkPath))) {
        Write-Host "Installing autohotkey.portable"
        choco install -y autohotkey.portable
    }
    $slui3Ahk = [System.IO.Path]::Combine($PSScriptRoot, "slui3.ahk")
    $action = New-ScheduledTaskAction -Execute $ahkPath -Argument "$slui3Ahk $key"
    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(10)
    $settings = New-ScheduledTaskSettingsSet `
        -Compatibility Win8 `
        -MultipleInstances IgnoreNew `
        -AllowStartIfOnBatteries `
        -DontStopIfGoingOnBatteries `
        -StartWhenAvailable -DeleteExpiredTaskAfter 00:00:01
    $principal = New-ScheduledTaskPrincipal -GroupId "BUILTIN\Administrators" -RunLevel Highest
    $task = Register-ScheduledTask -TaskName "WinKey" -InputObject (
        (
            New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description "Run Once to fix sysadmin things"
        ) | %{ $_.Triggers[0].EndBoundary = (Get-Date).AddSeconds(30).ToString('s') ; $_ }
    )
    $task | Start-ScheduledTask
    Write-Host "Started UI automation task"
}
```

Includes and closes #2